### PR TITLE
Improved main

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -3,8 +3,8 @@ buildConnFile: buildingConnection.csv
 buildingConfigPath: config/tsukuba-tu-building-data.csv
 jobsFile: config/jobs.csv
 businessFile: config/business.csv
-numberOfAgents: 1000
-threadNumber: 6
+numberOfAgents: 5000
+threadNumber: 10
 infectedAgent: 10
 vaccinationPercentage: 0.0
 verbose: false

--- a/config.yml
+++ b/config.yml
@@ -3,8 +3,8 @@ buildConnFile: buildingConnection.csv
 buildingConfigPath: config/tsukuba-tu-building-data.csv
 jobsFile: config/jobs.csv
 businessFile: config/business.csv
-numberOfAgents: 5000
-threadNumber: 10
+numberOfAgents: 1000
+threadNumber: 6
 infectedAgent: 10
 vaccinationPercentage: 0.0
 verbose: false

--- a/lib/Map/Map.py
+++ b/lib/Map/Map.py
@@ -260,7 +260,7 @@ class Map(osmium.SimpleHandler):
         """
         file = None
         connectionDict = {}
-        if buildConnFileName != "":
+        if buildConnFileName != None:
             Path(buildConnFileName).touch()
             file = open(buildConnFileName, "r+")
             connectionDict = self.buildConnectionDict(file)
@@ -416,7 +416,7 @@ class Map(osmium.SimpleHandler):
         """
         return rng.choice(self.buildingsDict[buildingType])
                     
-def readFile(OSMfilePath, buildConnFile="",grid = (10,10),buildingCSV = None):
+def readFile(OSMfilePath, buildConnFile=None,grid = (10,10),buildingCSV = None):
     """
     [Function] readFile
     Function to generate map fom osm File

--- a/lib/Map/Map.py
+++ b/lib/Map/Map.py
@@ -260,7 +260,7 @@ class Map(osmium.SimpleHandler):
         """
         file = None
         connectionDict = {}
-        if buildConnFileName != None:
+        if buildConnFileName is not None:
             Path(buildConnFileName).touch()
             file = open(buildConnFileName, "r+")
             connectionDict = self.buildConnectionDict(file)
@@ -276,7 +276,7 @@ class Map(osmium.SimpleHandler):
                 self.roadNodesDict[newNodes.osmId] = newNodes
             self.roadNodes.extend(generatedNodes)
 
-        if file != None:
+        if file is not None:
             file.close()
 
     def buildConnectionDict(self, file):

--- a/lib/Simulation/Simulator.py
+++ b/lib/Simulation/Simulator.py
@@ -174,7 +174,7 @@ class Simulator:
         # pathFindFile
         self.pathfindFile = None
         self.pathfindDict = {}
-        if pathfindFileName != "":
+        if pathfindFileName != None:
             Path(pathfindFileName).touch()
             self.pathfindFile = open(pathfindFileName, "r+")
             self.pathfindDict = self.buildPathfindDict()
@@ -203,23 +203,24 @@ class Simulator:
         print("Start building pathfind dict")
         startTime = time.time()
         pathfindDict={}
-        for line in self.pathfindFile.readlines():
-            if line[-1:] == "\n": # remove \n at the end of line if necessary
-                line = line[:-1]
-            try:
-                startNodeId, finishNodeId, distance, sequenceString = line.split(";")
-                startNodeId = int(startNodeId)
-                finishNodeId = int(finishNodeId)
+        if self.pathfindFile is not None:
+            for line in self.pathfindFile.readlines():
+                if line[-1:] == "\n": # remove \n at the end of line if necessary
+                    line = line[:-1]
+                try:
+                    startNodeId, finishNodeId, distance, sequenceString = line.split(";")
+                    startNodeId = int(startNodeId)
+                    finishNodeId = int(finishNodeId)
 
-                sequence = (eval(sequenceString), float(distance))
+                    sequence = (eval(sequenceString), float(distance))
 
-                if startNodeId not in pathfindDict:
-                    pathfindDict[startNodeId] = {}
-                pathfindDict[startNodeId][finishNodeId] = sequence
-            except ValueError:
-                # This exception occurs if the split does not return the correct number of arguments
-                # This means that or the csv is invalid or the line is wrong, in any case the process continues
-                continue
+                    if startNodeId not in pathfindDict:
+                        pathfindDict[startNodeId] = {}
+                    pathfindDict[startNodeId][finishNodeId] = sequence
+                except ValueError:
+                    # This exception occurs if the split does not return the correct number of arguments
+                    # This means that or the csv is invalid or the line is wrong, in any case the process continues
+                    continue
         print("Building pathfind dict took %.2fs"%(time.time() - startTime))
         return pathfindDict
 
@@ -579,3 +580,14 @@ class Simulator:
                 summary = i.summarize()
                 writer.writerow(summary)
             detailsFile.close()
+
+    def getAgentStatus(self):
+        # Possible status: Normal, Symptomatics, Severe
+        # Possible infectiousStatus: Susceptible, Exposed, Infectious, Recovered
+        status = {"Normal":0, "Symptomatics": 0, "Severe": 0}
+        seirStatus = {"Susceptible": 0, "Exposed": 0, "Infectious": 0, "Recovered": 0}
+
+        for ag in self.agents:
+            status[ag.status] += 1
+            seirStatus[ag.infectionStatus] += 1
+        return status, seirStatus

--- a/lib/Simulation/Simulator.py
+++ b/lib/Simulation/Simulator.py
@@ -174,7 +174,7 @@ class Simulator:
         # pathFindFile
         self.pathfindFile = None
         self.pathfindDict = {}
-        if pathfindFileName != None:
+        if pathfindFileName is not None:
             Path(pathfindFileName).touch()
             self.pathfindFile = open(pathfindFileName, "r+")
             self.pathfindDict = self.buildPathfindDict()
@@ -241,7 +241,7 @@ class Simulator:
         if finishNode.hashId not in self.pathfindDict[startNode.hashId]:
             self.pathfindDict[startNode.hashId][finishNode.hashId] = sequence
 
-            if self.pathfindFile != None:
+            if self.pathfindFile is not None:
                 seqToSave=[]
                 for mvVector in sequence.sequence:
                     start = mvVector.startingNode.hashId

--- a/main.py
+++ b/main.py
@@ -56,6 +56,7 @@ def parseArgs():
     global configFileName
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config_file", help="sets the config file")
+    parser.add_argument("-s", "--seed", type=int, help="sets the seed")
     parser.add_argument("--no_infectious_stop", action="store_true", help="Interromps the execution if infection is no longer possible")
     parser.add_argument("-nr", "no_render",  action="store_true", help="Execute the program without render" )
     args = parser.parse_args()
@@ -71,11 +72,15 @@ def parseArgs():
     if args.no_render:
         render = False
 
-    return configFileName, no_infectious_stop, render
+    seed = 1000
+    if args.seed:
+        seed = args.seed
+
+    return configFileName, no_infectious_stop, render, seed
     
 def main():
 
-    configFileName, no_infectious_stop, render = parseArgs()
+    configFileName, no_infectious_stop, render, seed = parseArgs()
     c = read_validate_config(configFileName)
 
     # Load the data
@@ -97,7 +102,8 @@ def main():
         infectedAgent = c["infectedAgent"],
         vaccinationPercentage = c["vaccinationPercentage"],
         reportPath = c["reportDir"],
-        reportInterval = c["reportInterval"])
+        reportInterval = c["reportInterval"],
+        seed=seed)
 
     if render:
         # Draw    

--- a/main.py
+++ b/main.py
@@ -56,26 +56,26 @@ def parseArgs():
     global configFileName
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config_file", help="sets the config file")
-    parser.add_argument("--no_susceptible_stop", action="store_true", help="Interromps the execution if there are no more susceptible agents")
+    parser.add_argument("--no_infectious_stop", action="store_true", help="Interromps the execution if infection is no longer possible")
     parser.add_argument("-nr", "no_render",  action="store_true", help="Execute the program without render" )
     args = parser.parse_args()
     
     if args.config_file:
         configFileName = args.config_file
-    no_susceptible_stop = False
+    no_infectious_stop = False
     
-    if args.no_susceptible_stop:
-        no_susceptible_stop = True
+    if args.no_infectious_stop:
+        no_infectious_stop = True
     render = True
     
     if args.no_render:
         render = False
 
-    return configFileName, no_susceptible_stop, render
+    return configFileName, no_infectious_stop, render
     
 def main():
 
-    configFileName, no_susceptible_stop, render = parseArgs()
+    configFileName, no_infectious_stop, render = parseArgs()
     c = read_validate_config(configFileName)
 
     # Load the data
@@ -111,7 +111,7 @@ def main():
         for x in range(0, dayToSimulate*24*3600, stepSize):
             sim.step(stepSize = stepSize)   
             _, seirStatus = sim.getAgentStatus()
-            if no_susceptible_stop and seirStatus["Susceptible"] == 0: 
+            if no_infectious_stop and seirStatus["Infectious"] + seirStatus["Exposed"] == 0: 
                 break
 
     sim.extract()

--- a/main_no_render.py
+++ b/main_no_render.py
@@ -55,20 +55,20 @@ def parseArgs():
     global configFileName
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config_file", help="sets the config file")
-    parser.add_argument("--no_susceptible_stop", action="store_true", help="Interromps the execution if there are no more susceptible agents")
+    parser.add_argument("--no_infectious_stop", action="store_true", help="Interromps the execution if there are no more susceptible agents")
     args = parser.parse_args()
     
     if args.config_file:
         configFileName = args.config_file
     
-    no_susceptible_stop = False
-    if args.no_susceptible_stop:
-        no_susceptible_stop = True
+    no_infectious_stop = False
+    if args.no_infectious_stop:
+        no_infectious_stop = True
 
-    return configFileName, no_susceptible_stop
+    return configFileName, no_infectious_stop
 
 def main():
-    configFileName, no_susceptible_stop = parseArgs()
+    configFileName, no_infectious_stop = parseArgs()
 
     c = read_validate_config(configFileName)
 
@@ -97,10 +97,10 @@ def main():
         reportInterval = c["reportInterval"])
         
     for x in range(0, dayToSimulate*24*3600, stepSize):
-        _, seirStatus = sim.getAgentStatus()
-        if no_susceptible_stop and seirStatus["Susceptible"] == 0: 
-            break
         sim.step(stepSize = stepSize)
+        _, seirStatus = sim.getAgentStatus()
+        if no_infectious_stop and seirStatus["Infectious"] + seirStatus["Exposed"] == 0: 
+            break
 
     sim.extract()
     sim.extractVisitLog()

--- a/main_no_render.py
+++ b/main_no_render.py
@@ -57,8 +57,10 @@ def parseArgs():
     parser.add_argument("-c", "--config_file", help="sets the config file")
     parser.add_argument("--no_susceptible_stop", action="store_true", help="Interromps the execution if there are no more susceptible agents")
     args = parser.parse_args()
+    
     if args.config_file:
         configFileName = args.config_file
+    
     no_susceptible_stop = False
     if args.no_susceptible_stop:
         no_susceptible_stop = True
@@ -67,7 +69,7 @@ def parseArgs():
 
 def main():
     configFileName, no_susceptible_stop = parseArgs()
-    print(configFileName, no_susceptible_stop)
+
     c = read_validate_config(configFileName)
 
     stepSize = c["nr_step_size"] #5 minutes

--- a/main_no_render.py
+++ b/main_no_render.py
@@ -1,20 +1,18 @@
 import sys
 import os
 import yaml
+import argparse
 # adds the root of the git dir to the import path
 # FIXME: Directory shenanigans
 root_dir = os.getcwd()
 sys.path.append(root_dir)
 import lib.Map.Map as mmap
-from lib.Renderer.Controller import Controller
-from lib.Renderer.Controller import View
 from lib.Simulation.Simulator import Simulator
 
 configFileName = "config.yml"
 
 requiredConfigs = [
     "OSMfile",
-    "buildConnFile",
     "jobsFile",
     "businessFile",
     "numberOfAgents",
@@ -30,6 +28,11 @@ requiredConfigs = [
     "nr_day_to_simulate",
 ]
 
+optionalConfig = [
+    "buildConnFile",
+    "pathfindFileName",
+]
+
 def read_validate_config(file_path):
     config = None
     with open(file_path, "r") as f:
@@ -42,31 +45,59 @@ def read_validate_config(file_path):
             errMessage += c + " "
     if err:
         raise NameError(errMessage)
+    for c in optionalConfig:
+        if c not in config:
+            config[c] = None
 
     return config
 
+def parseArgs():
+    global configFileName
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--config_file", help="sets the config file")
+    parser.add_argument("--no_susceptible_stop", action="store_true", help="Interromps the execution if there are no more susceptible agents")
+    args = parser.parse_args()
+    if args.config_file:
+        configFileName = args.config_file
+    no_susceptible_stop = False
+    if args.no_susceptible_stop:
+        no_susceptible_stop = True
+
+    return configFileName, no_susceptible_stop
+
 def main():
+    configFileName, no_susceptible_stop = parseArgs()
+    print(configFileName, no_susceptible_stop)
     c = read_validate_config(configFileName)
+
     stepSize = c["nr_step_size"] #5 minutes
     dayToSimulate = c["nr_day_to_simulate"]
+
     # Load the data
     gridSize = (c["gridHeight"], c["gridWidth"])
-    osmMap = mmap.readFile(c["OSMfile"], c["buildConnFile"], gridSize, c["buildingConfigPath"])
-
+    osmMap = mmap.readFile(
+        OSMfilePath = c["OSMfile"], 
+        buildConnFile = c["buildConnFile"],
+        grid = gridSize,
+        buildingCSV = c["buildingConfigPath"])
+    
     # Start Simulator
     sim = Simulator(
-        osmMap, 
-        c["jobsFile"],
-        c["businessFile"],
-        c["pathfindFileName"],
-        c["numberOfAgents"], 
-        c["threadNumber"], 
-        c["infectedAgent"], 
-        c["vaccinationPercentage"],
-        c["reportDir"],
-        c["reportInterval"])
-
+        osmMap = osmMap,
+        jobCSVPath = c["jobsFile"],
+        businessCVSPath = c["businessFile"],
+        pathfindFileName = c["pathfindFileName"],
+        agentNum = c["numberOfAgents"],
+        threadNumber = c["threadNumber"],
+        infectedAgent = c["infectedAgent"],
+        vaccinationPercentage = c["vaccinationPercentage"],
+        reportPath = c["reportDir"],
+        reportInterval = c["reportInterval"])
+        
     for x in range(0, dayToSimulate*24*3600, stepSize):
+        _, seirStatus = sim.getAgentStatus()
+        if no_susceptible_stop and seirStatus["Susceptible"] == 0: 
+            break
         sim.step(stepSize = stepSize)
 
     sim.extract()

--- a/main_no_render.py
+++ b/main_no_render.py
@@ -55,6 +55,7 @@ def parseArgs():
     global configFileName
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config_file", help="sets the config file")
+    parser.add_argument("-s", "--seed", type=int, help="sets the seed")
     parser.add_argument("--no_infectious_stop", action="store_true", help="Interromps the execution if there are no more susceptible agents")
     args = parser.parse_args()
     
@@ -65,10 +66,14 @@ def parseArgs():
     if args.no_infectious_stop:
         no_infectious_stop = True
 
-    return configFileName, no_infectious_stop
+    seed = 1000
+    if args.seed:
+        seed = args.seed
+
+    return configFileName, no_infectious_stop, seed
 
 def main():
-    configFileName, no_infectious_stop = parseArgs()
+    configFileName, no_infectious_stop, seed = parseArgs()
 
     c = read_validate_config(configFileName)
 
@@ -94,7 +99,8 @@ def main():
         infectedAgent = c["infectedAgent"],
         vaccinationPercentage = c["vaccinationPercentage"],
         reportPath = c["reportDir"],
-        reportInterval = c["reportInterval"])
+        reportInterval = c["reportInterval"],
+        seed=seed)
         
     for x in range(0, dayToSimulate*24*3600, stepSize):
         sim.step(stepSize = stepSize)


### PR DESCRIPTION
Now the main behaves correctly when not senf\ding the optional configs: buildConnFile and pathfindFileName.
Also added optional command-line arguments to the main.py and main_no_render.py. These are:

- --config_file:  You can specify the config file name, this is useful for writing a script that tests different configs. If this arg is not sent, the default filename ("config.yml") will be used
- --no_susceptible_stop: Another optional argument, it is only used if there is no render. It specifies that the execution will be stopped if there are no more people to be infected
- --no_render: Now you can execute the no-render from the mian.py \o/ 
- --seed: sets the random seed. If it is not sent the seed is 1000, maybe we should set it randomly if it is not sent but I didn't want to change the current behavior

Also changed back the config.yml to a lower agent/processor number since I believe most of us cant run it properly with too many agents. When testing we can go back to the higher numbers